### PR TITLE
fix: handle datetime conversion in checker to avoid ValueError with incorrect datetime format

### DIFF
--- a/searcher.py
+++ b/searcher.py
@@ -143,10 +143,13 @@ class TVTimeMovie(TVTimeItem):
         self.activity_type = row["type"]
 
         # Release date is available for movies
-
-        release_date = datetime.strptime(
-            row["release_date"], "%Y-%m-%d %H:%M:%S"
-        )
+        try:
+            release_date = datetime.strptime(
+                row["release_date"], "%Y-%m-%d %H:%M:%S"
+            )
+        except ValueError:
+            # Use current date to make the script work but this mght need to be changed.
+            release_date = datetime.today()
 
         # Check that date is valid
         if release_date.year > 1800:


### PR DESCRIPTION
I've got many movies with the `release_date` column in the csv being "0000-12-31 20:06:12". The script won't continue working when trying to process one of those. Hopefully this fix works without causing any issues as I've set the datetime to today when handling the exception.

EDIT: I did successfully import all my movies with this final fix.