### PR TITLE
Updated to work with the new GDPR data format

### DIFF
--- a/TimeToTrakt.py
+++ b/TimeToTrakt.py
@@ -82,8 +82,8 @@ def init_trakt_auth() -> bool:
     )
 
 
-def process_watched_shows() -> None:
-    with open(WATCHED_SHOWS_PATH, newline="", encoding="UTF-8") as csvfile:
+def process_watched_shows(path: str) -> None:
+    with open(path, newline="", encoding="UTF-8") as csvfile:
         reader = csv.DictReader(csvfile, delimiter=",")
         total_rows = len(list(reader))
         csvfile.seek(0, 0)
@@ -91,9 +91,10 @@ def process_watched_shows() -> None:
         # Ignore the header row
         next(reader, None)
         for rows_count, row in enumerate(reader):
+            if row["episode_number"] == "":  # if not an episode entry
+                continue
             tv_time_show = TVTimeTVShow(row)
             TVShowProcessor().process_item(tv_time_show, "{:.2f}%".format(rows_count / total_rows * 100))
-
 
 def process_watched_movies() -> None:
     with open(SHOWS_AND_MOVIES_PATH, newline="") as csvfile:
@@ -148,14 +149,16 @@ def start():
 
     if selection == 1:
         logging.info("Processing watched shows.")
-        process_watched_shows()
+        process_watched_shows(SHOWS_AND_MOVIES_PATH)
+        process_watched_shows(WATCHED_SHOWS_PATH)
         # TODO: Add support for followed shows
     elif selection == 2:
         logging.info("Processing movies.")
         process_watched_movies()
     elif selection == 3:
         logging.info("Processing both watched shows and movies.")
-        process_watched_shows()
+        process_watched_shows(SHOWS_AND_MOVIES_PATH)
+        process_watched_shows(WATCHED_SHOWS_PATH)
         process_watched_movies()
 
 

--- a/TimeToTrakt.py
+++ b/TimeToTrakt.py
@@ -97,7 +97,7 @@ def process_watched_shows(path: str) -> None:
             TVShowProcessor().process_item(tv_time_show, "{:.2f}%".format(rows_count / total_rows * 100))
 
 def process_watched_movies() -> None:
-    with open(SHOWS_AND_MOVIES_PATH, newline="") as csvfile:
+    with open(SHOWS_AND_MOVIES_PATH, newline="", encoding="UTF-8") as csvfile:
         reader = filter(lambda p: p["movie_name"] != "", csv.DictReader(csvfile, delimiter=","))
         watched_list = [row["movie_name"] for row in reader if row["type"] == "watch"]
         csvfile.seek(0, 0)

--- a/TimeToTrakt.py
+++ b/TimeToTrakt.py
@@ -66,10 +66,9 @@ def get_configuration() -> Config:
 
 config = get_configuration()
 
-WATCHED_SHOWS_PATH = config.gdpr_workspace_path + "/seen_episode.csv"
+WATCHED_SHOWS_PATH = config.gdpr_workspace_path + "/tracking-prod-records-v2.csv"
 FOLLOWED_SHOWS_PATH = config.gdpr_workspace_path + "/followed_tv_show.csv"
-MOVIES_PATH = config.gdpr_workspace_path + "/tracking-prod-records.csv"
-
+SHOWS_AND_MOVIES_PATH = config.gdpr_workspace_path + "/tracking-prod-records.csv"
 
 def init_trakt_auth() -> bool:
     if is_authenticated():
@@ -97,7 +96,7 @@ def process_watched_shows() -> None:
 
 
 def process_watched_movies() -> None:
-    with open(MOVIES_PATH, newline="") as csvfile:
+    with open(SHOWS_AND_MOVIES_PATH, newline="") as csvfile:
         reader = filter(lambda p: p["movie_name"] != "", csv.DictReader(csvfile, delimiter=","))
         watched_list = [row["movie_name"] for row in reader if row["type"] == "watch"]
         csvfile.seek(0, 0)

--- a/TimeToTrakt.py
+++ b/TimeToTrakt.py
@@ -93,6 +93,8 @@ def process_watched_shows(path: str) -> None:
         for rows_count, row in enumerate(reader):
             if row["episode_number"] == "":  # if not an episode entry
                 continue
+            if row["series_name"] == "":  # if the series name is blank
+                continue
             tv_time_show = TVTimeTVShow(row)
             TVShowProcessor().process_item(tv_time_show, "{:.2f}%".format(rows_count / total_rows * 100))
 

--- a/processor.py
+++ b/processor.py
@@ -190,7 +190,7 @@ class MovieProcessor(Processor):
 
     def _should_continue(self, tv_time_movie: TVTimeMovie) -> bool:
         # If movie is watched but this is an entry for watchlist, then skip
-        if tv_time_movie.name in self._watched_list and tv_time_movie.activity_type != "watch":
+        if tv_time_movie.name in self._watched_list and tv_time_movie.activity_type not in ["watch", "rewatch"]:
             logging.info(f"Skipping '{tv_time_movie.name}' to avoid redundant watchlist entry.")
             return False
 
@@ -207,7 +207,7 @@ class MovieProcessor(Processor):
             (watchlist_query.movie_name == tv_time_movie.name) & (watchlist_query.type == "watchlist")
         )
 
-        if tv_time_movie.activity_type == "watch":
+        if tv_time_movie.activity_type in ["watch", "rewatch"]:
             trakt_movie.mark_as_seen(tv_time_movie.date_watched)
             # Add the episode to the local database as imported, so it can be skipped,
             # if the process is repeated

--- a/searcher.py
+++ b/searcher.py
@@ -203,10 +203,10 @@ class Searcher(ABC):
             first_match = query_result[0]
             first_match_selected_index = int(first_match.get("UserSelectedIndex"))
             skip_show = first_match.get("Skip")
-            if skip_show is None:
-                return True, self.items_with_same_name[first_match_selected_index]
-            else:
+            if skip_show:
                 return True, None
+            else:
+                return True, self.items_with_same_name[first_match_selected_index]
         else:
             return False, None
 

--- a/searcher.py
+++ b/searcher.py
@@ -184,7 +184,7 @@ class Searcher(ABC):
         # If the user has not provided a manual selection already in the process
         # then prompt the user to make a selection
         else:
-            self._handle_multiple_manually()
+            return self._handle_multiple_manually()
 
     @abstractmethod
     def search_trakt(self, name: str) -> list[TraktItem]:

--- a/searcher.py
+++ b/searcher.py
@@ -143,6 +143,8 @@ class TVTimeMovie(TVTimeItem):
         self.activity_type = row["type"]
 
         # Release date is available for movies
+        if row["release_date"][0:4] == "0000":  # some entries had a release date of 0000
+            return
 
         release_date = datetime.strptime(
             row["release_date"], "%Y-%m-%d %H:%M:%S"

--- a/searcher.py
+++ b/searcher.py
@@ -105,9 +105,9 @@ class TVTimeItem:
 
 class TVTimeTVShow(TVTimeItem):
     def __init__(self, row: Any):
-        super().__init__(row["tv_show_name"], row["updated_at"])
+        super().__init__(row["series_name"], row["created_at"])
         self.episode_id = row["episode_id"]
-        self.season_number = row["episode_season_number"]
+        self.season_number = row["season_number"]
         self.episode_number = row["episode_number"]
 
     def parse_season_number(self, trakt_show: TraktTVShow) -> int:


### PR DESCRIPTION
Updated the file paths. When reading tv shows in it has to read from two files now.
Added some logic to deal with dodgy data too, unsure if its just my data or not. Shouldn't affect anything anyway.

- Some series names were blank so I had to skip over them (not really sure what to do about this)

- Some entries had a release date of 0000 so it now just leaves the release date blank. This means more manual input is required but at least it works.

I ran into an issue about rewatches not being marked but I am unsure how that worked previously. From my understanding, any movie/episode which is marked as seen is stored locally then if that movie/episode reappears it just skips over it. I think it would require a decent overhaul to fix this, unless I've misunderstood the functionality.

fix #52, fix #48, fix #45 I think. I managed to import all my movies and tv shows onto a dummy account no problems.
updated: fix #35 